### PR TITLE
WIP: 'beginningTimestampMillis'/'endTimestampMillis' to load messages from/to a specific timestamp

### DIFF
--- a/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicController.java
+++ b/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicController.java
@@ -95,17 +95,20 @@ public class TopicController {
             log.debug("TCM03 beginningOffsets={}", beginningOffsets);
             log.debug("TCM04 endOffsets={}", endOffsets);
 
+            long availablePartitions = Arrays.stream(partitionsArray).filter(p -> beginningOffsets.get(p) >= 0).count();
             for (int j : partitionsArray) {
                 Long startOffsetForPartition = beginningOffsets.get(j);
-
                 log.debug("TCM05 startOffsetForPartition={}", startOffsetForPartition);
-                long position = endOffsets.get(j) - offsetShift;
-                log.debug("TCM06 position={}", position);
-                long seekTo = position - (limit / partitionsArray.length);
                 if (startOffsetForPartition < 0) {
                     log.debug("TCM10 startOffsetForPartition is -1, seekToEnd");
                     consumer.seekToEnd(Collections.singletonList(topicPartitions.get(j)));
-                } else if (seekTo > startOffsetForPartition) {
+                    continue;
+                }
+
+                long position = endOffsets.get(j) - offsetShift;
+                log.debug("TCM06 position={}", position);
+                long seekTo = position - (limit / availablePartitions);
+                if (seekTo > startOffsetForPartition) {
                     log.debug("TCM11 seekTo={}", seekTo);
                     consumer.seek(topicPartitions.get(j), seekTo);
                 } else {

--- a/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicMessagesDto.java
+++ b/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicMessagesDto.java
@@ -14,6 +14,8 @@ public class TopicMessagesDto {
     @Singular
     private List<TopicMessage> messages;
 
+    private Map<Integer, Long> partitionBeginningOffsets;
+
     private Map<Integer, Long> partitionOffsets;
 
     private Map<Integer, Long> partitionEndOffsets;

--- a/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicMessagesDto.java
+++ b/kouncil-backend/src/main/java/com/consdata/kouncil/topic/TopicMessagesDto.java
@@ -14,8 +14,6 @@ public class TopicMessagesDto {
     @Singular
     private List<TopicMessage> messages;
 
-    private Map<Integer, Long> partitionBeginningOffsets;
-
     private Map<Integer, Long> partitionOffsets;
 
     private Map<Integer, Long> partitionEndOffsets;

--- a/kouncil-frontend/yarnw
+++ b/kouncil-frontend/yarnw
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ ! -f "./target/node/node" ] || [ ! -f "./target/node/yarn/dist/bin/yarn" ]; then
+  mkdir -p ./target/logs > /dev/null
+  {
+    echo "[$(date --rfc-3339=ns)] Downloading node and/or yarn"
+    mvn "com.github.eirslett:frontend-maven-plugin:install-node-and-yarn@install node and yarn"
+  } >> ./target/logs/yarnw.log 2>&1
+fi
+export PATH="$(pwd)/target/node:$(pwd)/target/node/yarn/dist/bin:$PATH"
+
+exec yarn $@
+#EOF


### PR DESCRIPTION
That query parameter allows to get messages from a specific timestamp instead of from the beginning.

```
$ curl 'http://localhost:4200/api/topic/messages/TestTopic2/2/latest?offset=0&limit=20'

{"messages":[{"key":"5","value":"5","timestamp":1619466681482,"partition":2,"offset":0},{"key":"6","value":"6","timestamp":1619466685304,"partition":2,"offset":1}],"partitionBeginningOffsets":{"0":0,"1":0,"2":0,"3":0},"partitionOffsets":{"0":0,"1":0,"2":0,"3":0},"partitionEndOffsets":{"0":2,"1":1,"2":2,"3":2},"totalResults":2}
```

```
$ curl 'http://localhost:4200/api/topic/messages/TestTopic2/2/latest?offset=0&limit=20&beginningTimestampMillis=1619466685304'

{"messages":[{"key":"6","value":"6","timestamp":1619466685304,"partition":2,"offset":1}],"partitionBeginningOffsets":{"0":0,"1":0,"2":0,"3":0},"partitionOffsets":{"0":0,"1":0,"2":1,"3":0},"partitionEndOffsets":{"0":2,"1":1,"2":2,"3":2},"totalResults":1}
```