### PR TITLE
Ikc 47 empty favourites problem

### DIFF
--- a/kouncil-frontend/src/app/consumers/consumer-groups/consumer-groups.component.ts
+++ b/kouncil-frontend/src/app/consumers/consumer-groups/consumer-groups.component.ts
@@ -1,7 +1,7 @@
 import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {Subscription} from 'rxjs';
 import {SearchService} from 'app/search.service';
-import {ConsumerGroup, ConsumerGroupsResponse} from 'app/consumers/consumer-groups/consumer-groups';
+import {ConsumerGroup} from 'app/consumers/consumer-groups/consumer-groups';
 import {ProgressBarService} from 'app/util/progress-bar.service';
 import {ArraySortPipe} from '../../util/array-sort.pipe';
 import {ConsumerGroupsService} from './consumer-groups.service';
@@ -11,7 +11,6 @@ import {ConfirmService} from '../../confirm/confirm.service';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {Servers} from '../../servers.service';
 import {FavouritesService} from '../../favourites.service';
-import {TopicMetadata} from '../../topics/topics';
 
 const CONSUMER_GROUP_FAVOURITE_KEY = 'kouncil-consumer-groups-favourites';
 
@@ -51,7 +50,7 @@ export class ConsumerGroupsComponent implements OnInit, OnDestroy {
     this.consumerGroupsService.getConsumerGroups(this.servers.getSelectedServerId())
       .pipe(first())
       .subscribe(data => {
-        this.consumerGroups = data.consumerGroups.map( t => new ConsumerGroup(t.groupId, t.status,  null));
+        this.consumerGroups = data.consumerGroups.map(t => new ConsumerGroup(t.groupId, t.status, null));
         this.favouritesService.applyFavourites(this.consumerGroups, CONSUMER_GROUP_FAVOURITE_KEY, this.servers.getSelectedServerId());
         this.filter();
         this.progressBarService.setProgress(false);
@@ -69,9 +68,14 @@ export class ConsumerGroupsComponent implements OnInit, OnDestroy {
   }
 
   onFavouriteClick(row) {
-    this.favouritesService.updateFavourites(row, CONSUMER_GROUP_FAVOURITE_KEY, this.servers.getSelectedServerId());
-    this.favouritesService.applyFavourites(this.consumerGroups, CONSUMER_GROUP_FAVOURITE_KEY, this.servers.getSelectedServerId());
-    this.filter(this.searchService.getCurrentPhrase());
+    this.progressBarService.setProgress(true);
+    this.filtered = [];
+    setTimeout(() => {
+      this.favouritesService.updateFavourites(row, CONSUMER_GROUP_FAVOURITE_KEY, this.servers.getSelectedServerId());
+      this.favouritesService.applyFavourites(this.consumerGroups, CONSUMER_GROUP_FAVOURITE_KEY, this.servers.getSelectedServerId());
+      this.filter(this.searchService.getCurrentPhrase());
+      this.progressBarService.setProgress(false);
+    });
   }
 
   deleteConsumerGroup(value) {

--- a/kouncil-frontend/src/app/topics/topics.component.ts
+++ b/kouncil-frontend/src/app/topics/topics.component.ts
@@ -61,22 +61,20 @@ export class TopicsComponent implements OnInit, OnDestroy {
   }
 
   private filter(phrase?) {
-    const tempFiltered = this.topics.filter((topicsMetadata) => {
+    this.filtered = this.topics.filter((topicsMetadata) => {
       return !phrase || topicsMetadata.name.indexOf(phrase) > -1;
     });
-    this.filtered.push(...tempFiltered);
-    this.filtered = [...this.filtered]; // Refresh the data
   }
 
   onFavouriteClick(row) {
+    this.progressBarService.setProgress(true);
     this.filtered = [];
-    this.filtered.push();
     setTimeout(() => {
       this.favouritesService.updateFavourites(row, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
       this.favouritesService.applyFavourites(this.topics, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
       this.filter(this.searchService.getCurrentPhrase());
-    }, 10);
-
+      this.progressBarService.setProgress(false);
+    });
   }
 
   navigateToTopic(event): void {

--- a/kouncil-frontend/src/app/topics/topics.component.ts
+++ b/kouncil-frontend/src/app/topics/topics.component.ts
@@ -1,5 +1,5 @@
 import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {TopicMetadata, Topics} from 'app/topics/topics';
+import {TopicMetadata} from 'app/topics/topics';
 import {Subscription} from 'rxjs';
 import {SearchService} from 'app/search.service';
 import {ProgressBarService} from '../util/progress-bar.service';
@@ -49,7 +49,7 @@ export class TopicsComponent implements OnInit, OnDestroy {
     this.topicsService.getTopics(this.servers.getSelectedServerId())
       .pipe(first())
       .subscribe(data => {
-        this.topics = data.topics.map( t => new TopicMetadata(t.partitions, null, t.name));
+        this.topics = data.topics.map(t => new TopicMetadata(t.partitions, null, t.name));
         this.favouritesService.applyFavourites(this.topics, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
         this.filter();
         this.progressBarService.setProgress(false);
@@ -61,15 +61,22 @@ export class TopicsComponent implements OnInit, OnDestroy {
   }
 
   private filter(phrase?) {
-    this.filtered = this.topics.filter((topicsMetadata) => {
+    const tempFiltered = this.topics.filter((topicsMetadata) => {
       return !phrase || topicsMetadata.name.indexOf(phrase) > -1;
     });
+    this.filtered.push(...tempFiltered);
+    this.filtered = [...this.filtered]; // Refresh the data
   }
 
   onFavouriteClick(row) {
-    this.favouritesService.updateFavourites(row, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
-    this.favouritesService.applyFavourites(this.topics, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
-    this.filter(this.searchService.getCurrentPhrase());
+    this.filtered = [];
+    this.filtered.push();
+    setTimeout(() => {
+      this.favouritesService.updateFavourites(row, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
+      this.favouritesService.applyFavourites(this.topics, TOPICS_FAVOURITE_KEY, this.servers.getSelectedServerId());
+      this.filter(this.searchService.getCurrentPhrase());
+    }, 10);
+
   }
 
   navigateToTopic(event): void {


### PR DESCRIPTION
Przyczyna błędów to core.js:6456 ERROR Error: NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: 'datatable-body-cell sort-active active'. Current value: 'datatable-body-cell sort-active'

Konsekwencji tego błędu jest kilka:

* znika tabelka po zaznaczeniu pierwszego elementu gdy ulubione są puste
* znikają "Wszystkie" gdy Ulubione są puste i klikamy inny niz pierwszy
* grupa "Ulubione" jest zwijana, jeśli dodajemy element do ulubionych i nie jest to pierwszy na liście
* itd....

(tak na marginesie, to ngx-datatable ma aktualnie otwartych 704 błędów i wiele z nich dotyczy naszej sytuacji, czyli niepoprawnego zachowania tabeli podczas dynamicznego tworzenie/usuwania grup)


po zapoznaniu sie z

* https://angular.io/errors/NG0100
* https://blog.angular-university.io/angular-debugging/

zastosowałem trick z setTtimeout bez czasu, zeby wymusić kolejny cykl javascriptowej pętli + czyszczenie listy topików/grup konsumentów