### PR TITLE
IKC-133 szukanie tracow zamiast czyszczenia inputow po kliknieciu enter

### DIFF
--- a/kouncil-frontend/src/app/track/track-filter/track-filter.component.ts
+++ b/kouncil-frontend/src/app/track/track-filter/track-filter.component.ts
@@ -56,7 +56,7 @@ import {TrackFilter, TrackOperator} from './track-filter';
           {{datesControl.errors['validation'].message}}
         </div>
       </div>
-      <button mat-button disableRipple class="clear-button" (click)="clearFilter()">Clear</button>
+      <button mat-button disableRipple class="clear-button" type="button" (click)="clearFilter()">Clear</button>
       <button mat-button disableRipple class="filter-button" [class.spinner]="loading" [disabled]="loading" (click)="setFilter()">Track events</button>
     </form>
   `,


### PR DESCRIPTION
Po kliknięciu entera na jednym z inputów, pola nie są już czyszczone tylko odpala się szukanie trackerów