### PR TITLE
IKC-136 zostawienie styli dla delete buttona

### DIFF
--- a/kouncil-frontend/src/styles/_ngx.scss
+++ b/kouncil-frontend/src/styles/_ngx.scss
@@ -116,8 +116,6 @@ ngx-datatable.ngx-datatable {
   display: none;
 }
 
-
-
 mat-icon.ngx-star-favourite {
   color: $blue-60;
   font-size: 24px;

--- a/kouncil-frontend/src/styles/_ngx.scss
+++ b/kouncil-frontend/src/styles/_ngx.scss
@@ -62,6 +62,26 @@ ngx-datatable.ngx-datatable {
   border-top: 1px solid $main-20;
   border-bottom: 1px solid $main-20;
   margin-bottom: -1px;
+
+  .ngx-action-button {
+    visibility: hidden;
+    background: $main-100;
+    color: $main-text-light-color;
+    font-size: 14px;
+    border-radius: $default-border-radius;
+    height: 32px;
+    border: none;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+
+  &:hover {
+    background: $main-10;
+
+    .ngx-action-button {
+      visibility: visible;
+    }
+  }
 }
 
 .ngx-actions-column {
@@ -95,6 +115,8 @@ ngx-datatable.ngx-datatable {
 .ngx-datatable.material datatable-progress {
   display: none;
 }
+
+
 
 mat-icon.ngx-star-favourite {
   color: $blue-60;


### PR DESCRIPTION
po wywaleniu buttona send, został usunięty też styl tego buttona, a jest potrzebny przy deletowaniu grup konsumerów